### PR TITLE
[feature] Clickable overlay to close log view

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -4,7 +4,7 @@
   font-size: 1rem;
   line-height: 1.2;
   font-family: "Noto Sans", sans-serif;
-  width: 284px;
+  width: var(--App-pockestHelperWidth);
   transition: 0.5s transform;
   border-top: 4px solid #d5a613;
 }
@@ -17,6 +17,7 @@
   --App-modeToggleOffset: calc(24px + 0.4rem);
   --App-updateOffset: 0rem;
   --App-errorOffset: 0rem;
+  --App-pockestHelperWidth: 284px;
 }
 
 .App--hasUpdate {

--- a/src/components/LogPanel/index.css
+++ b/src/components/LogPanel/index.css
@@ -52,3 +52,12 @@
 .LogPanel-close:hover {
   opacity: 0.6;
 }
+
+.LogPanel-overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: calc(100vw - var(--App-pockestHelperWidth));
+  height: 100vh;
+  /* background: rgba(0, 0, 0, 0.5) */
+}

--- a/src/components/LogPanel/index.tsx
+++ b/src/components/LogPanel/index.tsx
@@ -15,16 +15,19 @@ function LogPanel({ children }: LogPanelProps) {
     logStyle,
   } = React.useContext(AppContext);
   return (
-    <div className={cx('LogPanel', `LogPanel--${logStyle}`)}>
-      <button
-        className="LogPanel-close"
-        type="button"
-        onClick={() => setShowLog && setShowLog(false)}
-      >
-        «
-      </button>
-      {children}
-    </div>
+    <>
+      <div onClick={() => setShowLog && setShowLog(false)} className="LogPanel-overlay" />
+      <div className={cx('LogPanel', `LogPanel--${logStyle}`)}>
+        <button
+          className="LogPanel-close"
+          type="button"
+          onClick={() => setShowLog && setShowLog(false)}
+        >
+          «
+        </button>
+        {children}
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Not sure if you wanted this or not so feel free to reject this PR, though I thought it might be helpful to have an invisible overlay that is behind the log view so users can click it to close the log view, similar to how dismissable dialogs behave when you click their overlay. I often like to check the log and close it again so I can see the monsters, and I find this faster to do so. Not sure if everyone's usage of the extension is similar so it may not be useful for everyone.

The code change has a transparent overlay so it looks the same, it just captures clicks to close the log view.

I also have a screen recording of a semi-transparent one (just one line of CSS) in case you wanted that, which is mostly useful for debugging the size and z-position of the overlay, but I think transparent is better to not obscure any of the page.

The diff in `LogPanel/index.tsx` is mostly whitespace changes (wrap the overlay `div` and existing code in a fragment) so viewing with whitespace changes hidden may be preferable.

The CSS positioning is to avoid overlaying on top of the main helper view so that the UI is still functional with the log view open.

If you're interested in this change, please test it out and let me know if you find any issues.

## Transparent overlay (included in code change)

![overlay click - transparent](https://github.com/user-attachments/assets/083d7440-f921-48c8-9fe0-f912681eccbe)


## Semi-transparent overlay, 50% black (commented out but useful for debugging the size and position of the overlay)

![overlay click - 50% black](https://github.com/user-attachments/assets/d80c391e-45c8-4ccd-8ff3-8d4f4a478df5)

